### PR TITLE
修复系统和进程cpu占用率不准的问题

### DIFF
--- a/runtime/agentCpu_linux.go
+++ b/runtime/agentCpu_linux.go
@@ -1,0 +1,141 @@
+package runtime
+
+import (
+	"errors"
+	"math"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+)
+
+// func GetCPUpct() (float64, error) {
+//
+//		return cpuUsage, nil
+//	}
+var latestCpuPct float64
+var latestProcessCpuPct float64
+var historyStat Stat
+var historyLock sync.Mutex
+var clkTck float64 = 100 // 默认100
+
+type Stat struct {
+	utime  float64
+	stime  float64
+	cutime float64
+	cstime float64
+	start  float64
+	rss    float64
+	uptime float64
+}
+
+func GetCurrentProcessCPUpct() (float64, float64, error) {
+	pct, err := cpu.Percent(5000*time.Millisecond, false)
+	if err != nil {
+		return -1, -1, err
+	}
+	currentProcessCpuUsage, err := GetStat(os.Getpid())
+	if err != nil {
+		return -1, -1, err
+	}
+	// currentProcessCpuUsage, err := agt.CPUPercent()
+	// if err != nil {
+	// 	return -1, -1, err
+	// }
+	latestCpuPct = pct[0]
+	latestProcessCpuPct = currentProcessCpuUsage
+
+	return pct[0], currentProcessCpuUsage, nil
+}
+
+func GetCurrentProcessCPUpctLatest() (float64, float64, error) {
+	// 从环形缓存中读取
+	//var CPUpct float64
+	//var CurrentProcessCPUpct float64
+	//
+	//CPUpct = 0
+	//CurrentProcessCPUpct = 0
+	//if rb.os.cpu.Value != nil {
+	//	CPUpct = rb.os.cpu.Value.(float64)
+	//}
+	//if rb.agent.cpu.Value != nil {
+	//	CurrentProcessCPUpct = rb.agent.cpu.Value.(float64)
+	//}
+	//
+	//return CPUpct, CurrentProcessCPUpct, nil
+
+	return latestCpuPct, latestProcessCpuPct, nil
+}
+
+func init() {
+	historyStat = Stat{}
+}
+
+func parseFloat(val string) float64 {
+	floatVal, _ := strconv.ParseFloat(val, 64)
+	return floatVal
+}
+
+func GetStat(pid int) (float64, error) {
+	uptimeFileBytes, err := os.ReadFile(path.Join("/proc", "uptime"))
+	if err != nil {
+		return -1, err
+	}
+	uptime := parseFloat(strings.Split(string(uptimeFileBytes), " ")[0])
+
+	procStatFileBytes, err := os.ReadFile(path.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return -1, err
+	}
+	splitAfter := strings.SplitAfter(string(procStatFileBytes), ")")
+
+	if len(splitAfter) == 0 || len(splitAfter) == 1 {
+		return -1, errors.New("Can't find process with this PID: " + strconv.Itoa(pid))
+	}
+	infos := strings.Split(splitAfter[1], " ")
+	stat := &Stat{
+		utime:  parseFloat(infos[12]),
+		stime:  parseFloat(infos[13]),
+		cutime: parseFloat(infos[14]),
+		cstime: parseFloat(infos[15]),
+		start:  parseFloat(infos[20]) / clkTck,
+		rss:    parseFloat(infos[22]),
+		uptime: uptime,
+	}
+
+	_stime := 0.0
+	_utime := 0.0
+
+	historyLock.Lock()
+	defer historyLock.Unlock()
+
+	_history := historyStat
+
+	if _history.stime != 0 {
+		_stime = _history.stime
+	}
+
+	if _history.utime != 0 {
+		_utime = _history.utime
+	}
+	total := stat.stime - _stime + stat.utime - _utime
+	total = total / clkTck
+
+	seconds := stat.start - uptime
+	if _history.uptime != 0 {
+		seconds = uptime - _history.uptime
+	}
+
+	seconds = math.Abs(seconds)
+	if seconds == 0 {
+		seconds = 1
+	}
+
+	historyStat = *stat
+	cpu := (total / seconds) * 100
+	return cpu, nil
+}

--- a/runtime/agentCpu_windows.go
+++ b/runtime/agentCpu_windows.go
@@ -1,0 +1,150 @@
+package runtime
+
+import (
+	"fmt"
+	"math"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32         = syscall.NewLazyDLL("kernel32.dll")
+	procGetSystemTimes  = modkernel32.NewProc("GetSystemTimes")
+	procGetProcessTimes = modkernel32.NewProc("GetProcessTimes")
+)
+
+type FILETIME struct {
+	dwLowDateTime  uint64
+	dwHighDateTime uint64
+}
+
+var latestCpuPct float64
+var latestProcessCpuPct float64
+
+var m_preidleTime = FILETIME{}
+var m_prekernelTime = FILETIME{}
+var m_preuserTime = FILETIME{}
+var m_agentCpuTime int64 = 0
+
+func CompareFileTime2(time1 FILETIME, time2 FILETIME) int64 {
+	a := int64((time1.dwHighDateTime)<<32 | time1.dwLowDateTime)
+	b := int64((time2.dwHighDateTime)<<32 | time2.dwLowDateTime)
+	return b - a
+}
+
+func GetCPUpct() (float64, error) {
+	var idleTime, kernelTime, userTime FILETIME
+
+	// 调用GetSystemTimes函数
+	ret, _, err := procGetSystemTimes.Call(
+		uintptr(unsafe.Pointer(&idleTime)),
+		uintptr(unsafe.Pointer(&kernelTime)),
+		uintptr(unsafe.Pointer(&userTime)),
+	)
+	if ret == 0 {
+		fmt.Println("Error:", err)
+		return -1, err
+	}
+
+	idle := CompareFileTime2(m_preidleTime, idleTime)
+	kernel := CompareFileTime2(m_prekernelTime, kernelTime)
+	user := CompareFileTime2(m_preuserTime, userTime)
+	var cpuUsage float64
+	cpuUsage = 0
+	if kernel+user == 0 {
+		cpuUsage = 0
+	} else {
+		//（总的时间-空闲时间）/总的时间=占用cpu的时间就是使用率
+		cpuUsage = math.Abs(float64((kernel+user-idle)*100) / float64(kernel+user))
+	}
+	m_preidleTime = idleTime
+	m_prekernelTime = kernelTime
+	m_preuserTime = userTime
+
+	return cpuUsage, nil
+}
+
+func GetCurrentProcessCPUpct() (float64, float64, error) {
+	// 获取系统cpu时间
+	var idleTime, kernelTime, userTime FILETIME
+
+	// 调用GetSystemTimes函数
+	ret, _, err := procGetSystemTimes.Call(
+		uintptr(unsafe.Pointer(&idleTime)),
+		uintptr(unsafe.Pointer(&kernelTime)),
+		uintptr(unsafe.Pointer(&userTime)),
+	)
+	if ret == 0 {
+		fmt.Println("Error:", err)
+		return -1, -1, err
+	}
+
+	// 获取进程句柄
+	processHandle, err := syscall.GetCurrentProcess()
+	if err != nil {
+		fmt.Println("无法获取当前进程句柄:", err)
+		return -1, -1, err
+	}
+	defer syscall.CloseHandle(processHandle)
+
+	// 获取当前进程的 CPU 时间
+	var creationTimeAgent, exitTimeAgent, kernelTimeAgent, userTimeAgent FILETIME
+
+	// 获取进程时间信息
+	err = syscall.GetProcessTimes(processHandle,
+		(*syscall.Filetime)(unsafe.Pointer(&creationTimeAgent)),
+		(*syscall.Filetime)(unsafe.Pointer(&exitTimeAgent)),
+		(*syscall.Filetime)(unsafe.Pointer(&kernelTimeAgent)),
+		(*syscall.Filetime)(unsafe.Pointer(&userTimeAgent)))
+	if err != nil {
+		fmt.Println("无法获取当前进程cpu时间:", err)
+		return -1, -1, err
+	}
+	// 计算 CPU 时间
+	agentCpuTime := int64((kernelTimeAgent.dwHighDateTime)<<32|kernelTimeAgent.dwLowDateTime) + int64((userTimeAgent.dwHighDateTime)<<32|userTimeAgent.dwLowDateTime)
+
+	idle := CompareFileTime2(m_preidleTime, idleTime)
+	kernel := CompareFileTime2(m_prekernelTime, kernelTime)
+	user := CompareFileTime2(m_preuserTime, userTime)
+	agent := agentCpuTime - m_agentCpuTime
+	var cpuUsage float64
+	var currentProcessCpuUsage float64
+
+	cpuUsage = 0
+	currentProcessCpuUsage = 0
+	if kernel+user == 0 {
+		cpuUsage = 0
+	} else {
+		//（总的时间-空闲时间）/总的时间=占用cpu的时间就是使用率
+		cpuUsage = math.Abs(float64((kernel+user-idle)*100) / float64(kernel+user))
+		currentProcessCpuUsage = math.Abs(float64(agent*100) / float64(kernel+user))
+	}
+	m_preidleTime = idleTime
+	m_prekernelTime = kernelTime
+	m_preuserTime = userTime
+	m_agentCpuTime = agentCpuTime
+
+	latestCpuPct = cpuUsage
+	latestProcessCpuPct = currentProcessCpuUsage
+
+	return cpuUsage, currentProcessCpuUsage, nil
+}
+
+func GetCurrentProcessCPUpctLatest() (float64, float64, error) {
+	// 从环形缓存中读取
+	//var CPUpct float64
+	//var CurrentProcessCPUpct float64
+	//
+	//CPUpct = 0
+	//CurrentProcessCPUpct = 0
+	//if rb.os.cpu.Value != nil {
+	//	CPUpct = rb.os.cpu.Value.(float64)
+	//}
+	//if rb.agent.cpu.Value != nil {
+	//	CurrentProcessCPUpct = rb.agent.cpu.Value.(float64)
+	//}
+	//
+	//return CPUpct, CurrentProcessCPUpct, nil
+
+	return latestCpuPct, latestProcessCpuPct, nil
+}


### PR DESCRIPTION
改进了进程cpu占用的计算方法 (windows 和linux分别实现,  抛弃gopsutil)
不获取很短时间内实时的cpu占用了,  统一取5秒的平均cpu时间占用的数据;
